### PR TITLE
Changes MainFragment to use ListRow instead of PageRow to demonstrate the issue with blinking ListRows

### DIFF
--- a/rows-update/app/src/main/java/me/admqueiroga/example/MainFragment.kt
+++ b/rows-update/app/src/main/java/me/admqueiroga/example/MainFragment.kt
@@ -2,27 +2,51 @@ package me.admqueiroga.example
 
 import android.os.Bundle
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 import androidx.leanback.app.BrowseSupportFragment
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.HeaderItem
-import androidx.leanback.widget.ListRowPresenter
-import androidx.leanback.widget.PageRow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 /**
  * Loads a grid of cards with movies to browse.
  */
 class MainFragment : BrowseSupportFragment() {
 
+
+    private val cardPresenter = CardPresenter()
+    private var coroutineScope = CoroutineScope(Dispatchers.Main)
+
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        mainFragmentRegistry.registerFragment(PageRow::class.java, PageFragmentsFactory)
-
+        adapter = ArrayObjectAdapter(MoviesListRowPresenter())
         setupUIElements()
+        coroutineScope.launch {
+            while (true) {
+                loadRows()
+                delay(5000)
+            }
+        }
+    }
 
-        val pagesAdapter = ArrayObjectAdapter(ListRowPresenter())
-        pagesAdapter.add(PageRow(HeaderItem(MOVIES)))
-        adapter = pagesAdapter
+    private fun loadRows() {
+        val listRows = mutableListOf<MovieListRow>()
+        val list = MovieList.list
+        for (i in 0 until NUM_ROWS) {
+            val listRowAdapter = ArrayObjectAdapter(cardPresenter)
+            for (j in 0 until Random.nextInt(5, NUM_COLS)) {
+                listRowAdapter.add(list[j % 5])
+            }
+            val header = HeaderItem(i.toLong(), "Category($i) - ${System.currentTimeMillis()}")
+            listRows.add(MovieListRow(header, listRowAdapter))
+        }
+        val rowsAdapter = adapter as ArrayObjectAdapter
+
+        // TODO: Replace MovieListRowDiffCallback with null to check the adapter behavior.
+        rowsAdapter.setItems(listRows, MovieListRowDiffCallback)
     }
 
     private fun setupUIElements() {
@@ -30,18 +54,9 @@ class MainFragment : BrowseSupportFragment() {
         brandColor = ContextCompat.getColor(activity!!, R.color.cyan_background)
     }
 
-    private object PageFragmentsFactory : FragmentFactory<Fragment>() {
-        override fun createFragment(row: Any?): Fragment {
-            row as PageRow
-            return when (row.headerItem.name) {
-                MOVIES -> MovieRowsFragment()
-                else -> throw Exception("Unable to instantiate fragment for PageRow named '${row.headerItem.name}'")
-            }
-        }
-    }
-
     companion object {
-        private const val MOVIES = "Movies"
-    }
+        private const val NUM_ROWS = 6
+        private const val NUM_COLS = 15
 
+    }
 }


### PR DESCRIPTION
When using ListRow instead of PageRow the payload created by the DiffUtil in BrowseSupportFragment gets "Stolen" by the HeaderPresenter and the ListRowPresenter does not pick it up, This causes blinking in the list and losing the position of the selected item